### PR TITLE
add new versions and fix certificates

### DIFF
--- a/0.35.2/rockcraft.yaml
+++ b/0.35.2/rockcraft.yaml
@@ -40,10 +40,14 @@ parts:
       agent.yaml: etc/agent/agent.yaml
     stage:
       - etc/agent/agent.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:
       - grafana-agent
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/0.35.4/rockcraft.yaml
+++ b/0.35.4/rockcraft.yaml
@@ -40,10 +40,14 @@ parts:
       agent.yaml: etc/agent/agent.yaml
     stage:
       - etc/agent/agent.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:
       - grafana-agent
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/0.37.4/rockcraft.yaml
+++ b/0.37.4/rockcraft.yaml
@@ -40,10 +40,14 @@ parts:
       agent.yaml: etc/agent/agent.yaml
     stage:
       - etc/agent/agent.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:
       - grafana-agent
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/0.38.1/rockcraft.yaml
+++ b/0.38.1/rockcraft.yaml
@@ -40,10 +40,14 @@ parts:
       agent.yaml: etc/agent/agent.yaml
     stage:
       - etc/agent/agent.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:
       - grafana-agent
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/0.39.0/rockcraft.yaml
+++ b/0.39.0/rockcraft.yaml
@@ -40,9 +40,13 @@ parts:
       agent.yaml: etc/agent/agent.yaml
     stage:
       - etc/agent/agent.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:
+      - ca-certs
       - grafana-agent
     override-prime: |
       set -x

--- a/0.39.1/rockcraft.yaml
+++ b/0.39.1/rockcraft.yaml
@@ -40,10 +40,14 @@ parts:
       agent.yaml: etc/agent/agent.yaml
     stage:
       - etc/agent/agent.yaml
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
   deb-security-manifest:
     plugin: nil
     after:
       - grafana-agent
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/0.39.2/agent.yaml
+++ b/0.39.2/agent.yaml
@@ -1,0 +1,17 @@
+server:
+  log_level: info
+
+metrics:
+  global:
+    scrape_interval: 1m
+  configs:
+    - name: test
+      host_filter: false
+      scrape_configs:
+        - job_name: local_scrape
+          static_configs:
+            - targets: ['127.0.0.1:12345']
+              labels:
+                cluster: 'localhost'
+      remote_write:
+        - url: http://localhost:9009/api/prom/push

--- a/0.39.2/rockcraft.yaml
+++ b/0.39.2/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: grafana-agent
 summary: Grafana Agent in a ROCK.
 description: "Grafana Agent is a single binary collector for metrics and logging, useful for per-node metrics or proxying from edge endpoints."
-version: "0.38.0"
+version: "0.39.2"
 base: ubuntu@22.04
 build-base: ubuntu@22.04
 license: Apache-2.0
@@ -18,7 +18,7 @@ parts:
     plugin: go
     source: https://github.com/grafana/agent
     source-type: git
-    source-tag: "v0.38.0"
+    source-tag: "v0.39.2"
     build-snaps:
       - go/1.21/stable
     build-environment:

--- a/0.40.2/rockcraft.yaml
+++ b/0.40.2/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: grafana-agent
 summary: Grafana Agent in a ROCK.
 description: "Grafana Agent is a single binary collector for metrics and logging, useful for per-node metrics or proxying from edge endpoints."
-version: "0.38.0"
+version: "0.40.2"
 base: ubuntu@22.04
 build-base: ubuntu@22.04
 license: Apache-2.0
@@ -18,7 +18,7 @@ parts:
     plugin: go
     source: https://github.com/grafana/agent
     source-type: git
-    source-tag: "v0.38.0"
+    source-tag: "v0.40.2"
     build-snaps:
       - go/1.21/stable
     build-environment:


### PR DESCRIPTION
## Issue
Currently, the `ca-certificates` package is added to the rock, but it's missing the default certificates in `/etc/ssl/certs`.

This happens not because we don't stage them, but because `stage-packages: [ca-certificates]` doesn't run the maintainer scripts that would populate `/etc/ssl/certs`, so that folder stays empty.

## Solution
The solution to this is to change `stage-packages:` to `overlay-packages` in the `ca-certs` part, because that also runs the maintainer scripts and correctly populates the `/ets/ssl/certs` folder.

## Testing Instructions

You can test it yourself by simply running the rock and checking the certs are there via `ls /etc/ssl/certs`.

```bash
root@8f0199aebc08:/# which update-ca-certificates
/usr/sbin/update-ca-certificates
root@8f0199aebc08:/# ll /etc/ssl/certs/
total 604
```